### PR TITLE
fix: add --base branch detection to gh pr create

### DIFF
--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -343,9 +343,10 @@ elif echo "$TASK" | grep -qi "doc"; then
 fi
 
 # Detect base branch (prefer develop, fallback to default)
-BASE_BRANCH=$(git remote show origin | grep 'HEAD branch' | cut -d: -f2 | xargs)
 if git branch -r | grep -q "origin/develop"; then
   BASE_BRANCH="develop"
+else
+  BASE_BRANCH=$(git remote show origin | grep 'HEAD branch' | cut -d: -f2 | xargs)
 fi
 echo "Base branch: $BASE_BRANCH"
 

--- a/.claude/commands/td.md
+++ b/.claude/commands/td.md
@@ -309,9 +309,10 @@ EOF
 git push -u origin "$DOCS_BRANCH"
 
 # 9. Detect base branch (prefer develop, fallback to default)
-BASE_BRANCH=$(git remote show origin | grep 'HEAD branch' | cut -d: -f2 | xargs)
 if git branch -r | grep -q "origin/develop"; then
   BASE_BRANCH="develop"
+else
+  BASE_BRANCH=$(git remote show origin | grep 'HEAD branch' | cut -d: -f2 | xargs)
 fi
 echo "Base branch: $BASE_BRANCH"
 


### PR DESCRIPTION
## Summary

Add `--base` branch detection to `gh pr create` commands in `/pr` and `/td` skills.

## Changes Made

- `.claude/commands/pr.md` - Added base branch detection logic
- `.claude/commands/td.md` - Added base branch detection logic

### Logic Added
```bash
# Detect base branch (prefer develop, fallback to default)
BASE_BRANCH=$(git remote show origin | grep 'HEAD branch' | cut -d: -f2 | xargs)
if git branch -r | grep -q "origin/develop"; then
  BASE_BRANCH="develop"
fi
```

## Testing

- [x] Verified syntax is correct
- [x] Logic detects `develop` branch if exists
- [x] Falls back to default branch if `develop` doesn't exist

## Related Issues

Fixes #20