### PR TITLE
chore: sync assets/commands with .claude/commands

### DIFF
--- a/assets/commands/pr.md
+++ b/assets/commands/pr.md
@@ -342,7 +342,16 @@ elif echo "$TASK" | grep -qi "doc"; then
   TYPE="docs"
 fi
 
+# Detect base branch (prefer develop, fallback to default)
+if git branch -r | grep -q "origin/develop"; then
+  BASE_BRANCH="develop"
+else
+  BASE_BRANCH=$(git remote show origin | grep 'HEAD branch' | cut -d: -f2 | xargs)
+fi
+echo "Base branch: $BASE_BRANCH"
+
 gh pr create \
+  --base "$BASE_BRANCH" \
   --title "$TYPE: $TASK" \
   --body "$(cat <<EOF
 ## Summary

--- a/assets/commands/recap.md
+++ b/assets/commands/recap.md
@@ -62,6 +62,17 @@ Options:
 
 ```bash
 export TZ='Asia/Bangkok'
+
+# Get branch from current.md
+EXPECTED_BRANCH=$(grep "^BRANCH:" docs/current.md | cut -d: -f2- | xargs)
+CURRENT_BRANCH=$(git branch --show-current)
+
+# Switch to correct branch if needed
+if [ -n "$EXPECTED_BRANCH" ] && [ "$EXPECTED_BRANCH" != "-" ] && [ "$CURRENT_BRANCH" != "$EXPECTED_BRANCH" ]; then
+  echo "⚠️  Switching to branch: $EXPECTED_BRANCH"
+  git checkout "$EXPECTED_BRANCH"
+fi
+
 # Update state to working if it was pending
 sed -i '' 's/STATE: pending/STATE: working/' docs/current.md
 echo "$(date '+%Y-%m-%d %H:%M') | working | [TASK] (resumed)" >> docs/logs/activity.log
@@ -70,6 +81,7 @@ echo "$(date '+%Y-%m-%d %H:%M') | working | [TASK] (resumed)" >> docs/logs/activ
 แสดง:
 ```
 พร้อมทำต่อ: [TASK]
+Branch: [BRANCH]
 ```
 
 **ถ้าเลือก "เริ่มงานใหม่":**
@@ -90,12 +102,16 @@ fi
 # Get current task info
 TASK=$(grep "^TASK:" docs/current.md | cut -d: -f2- | xargs)
 SINCE=$(grep "^SINCE:" docs/current.md | cut -d: -f2- | xargs)
+BRANCH=$(grep "^BRANCH:" docs/current.md | cut -d: -f2- | xargs)
+ISSUE=$(grep "^ISSUE:" docs/current.md | cut -d: -f2- | xargs)
 
 # Append to WIP.md
 echo "## $TASK" >> docs/WIP.md
 echo "" >> docs/WIP.md
 echo "- **Started:** $SINCE" >> docs/WIP.md
 echo "- **Paused:** $(date '+%Y-%m-%d %H:%M')" >> docs/WIP.md
+echo "- **Branch:** $BRANCH" >> docs/WIP.md
+echo "- **Issue:** $ISSUE" >> docs/WIP.md
 echo "- **Status:** Incomplete" >> docs/WIP.md
 echo "" >> docs/WIP.md
 ```
@@ -115,6 +131,8 @@ cat > docs/current.md << 'EOF'
 STATE: ready
 TASK: -
 SINCE: -
+ISSUE: -
+BRANCH: -
 EOF
 ```
 
@@ -151,6 +169,8 @@ fi
 STATE: [state]
 TASK: [task]
 SINCE: [since]
+ISSUE: [issue]
+BRANCH: [branch]
 
 ### Recent Activity
 [last 5 entries]

--- a/assets/commands/td.md
+++ b/assets/commands/td.md
@@ -308,8 +308,17 @@ EOF
 # 8. Push branch ใหม่
 git push -u origin "$DOCS_BRANCH"
 
-# 9. สร้าง PR ใหม่สำหรับ docs
+# 9. Detect base branch (prefer develop, fallback to default)
+if git branch -r | grep -q "origin/develop"; then
+  BASE_BRANCH="develop"
+else
+  BASE_BRANCH=$(git remote show origin | grep 'HEAD branch' | cut -d: -f2 | xargs)
+fi
+echo "Base branch: $BASE_BRANCH"
+
+# 10. สร้าง PR ใหม่สำหรับ docs
 gh pr create \
+  --base "$BASE_BRANCH" \
   --title "docs: retrospective for #$ISSUE" \
   --body "$(cat <<'EOF'
 ## Summary

--- a/docs/current.md
+++ b/docs/current.md
@@ -1,5 +1,5 @@
-STATE: completed
-TASK: fix: gh pr create should specify --base branch
-SINCE: 2026-01-14 02:28
-ISSUE: #20
-BRANCH: fix/20-gh-pr-create-base-branch
+STATE: working
+TASK: fix: /pr skill uses quoted heredoc preventing date substitution
+SINCE: 2026-01-14 02:59
+ISSUE: #24
+BRANCH: fix/24-heredoc-date-substitution

--- a/docs/logs/activity.log
+++ b/docs/logs/activity.log
@@ -16,3 +16,4 @@
 2026-01-12 10:09 | working | fix: pr-review skill should include commit hash in replies (#17)
 2026-01-12 11:44 | completed | fix: pr-review skill should include commit hash in replies (#17)
 2026-01-14 02:29 | completed | fix: gh pr create should specify --base branch (#20)
+2026-01-14 02:59 | working | fix: /pr skill uses quoted heredoc preventing date substitution (#24)


### PR DESCRIPTION
## Summary

Sync `assets/commands/` with `.claude/commands/` to include recent changes.

## Changes

- `assets/commands/pr.md` - Added base branch detection from #20
- `assets/commands/td.md` - Added base branch detection from #20
- `assets/commands/recap.md` - Synced

## Issue #24 Investigation

Issue #24 reported that `/pr` skill uses quoted heredoc preventing date substitution.
After investigation, this bug **cannot be reproduced**:
- All heredocs with `$(date ...)` use unquoted `<<EOF`
- Quoted `<<'EOF'` is only used for templates with placeholders

Issue #24 closed as "cannot reproduce".

## Related

- Closes investigation for #24