### PR TITLE
docs: retrospective for knowledge distillation

### DIFF
--- a/docs/current.md
+++ b/docs/current.md
@@ -1,5 +1,5 @@
 STATE: completed
-TASK: Roadmap creation, README update, discussions response
-SINCE: 2026-01-14 22:54
+TASK: Knowledge distillation from retrospectives
+SINCE: 2026-01-14 23:09
 ISSUE: #24
-BRANCH: main
+BRANCH: knowledge/distill-patterns

--- a/docs/logs/activity.log
+++ b/docs/logs/activity.log
@@ -19,3 +19,4 @@
 2026-01-14 02:59 | working | fix: /pr skill uses quoted heredoc preventing date substitution (#24)
 2026-01-14 03:24 | completed | Session: #20 fix, #24 investigation, auto-release workflow
 2026-01-14 22:54 | completed | Roadmap & docs update, discussions #36 #39
+2026-01-14 23:09 | completed | Knowledge distill: heredoc, git-workflow, github-api

--- a/docs/retrospective/2026-01/retrospective_2026-01-14_230857.md
+++ b/docs/retrospective/2026-01/retrospective_2026-01-14_230857.md
@@ -1,0 +1,126 @@
+---
+date: 2026-01-14T23:08:00+07:00
+type: docs
+status: completed
+tags: [knowledge-base, distill, patterns, documentation]
+branch: knowledge/distill-patterns
+issue: "#24"
+duration: ~30m
+files_changed:
+  - docs/knowledge-base/heredoc-quoting.md
+  - docs/knowledge-base/git-workflow-patterns.md
+  - docs/knowledge-base/github-api-patterns.md
+---
+
+# Session: Knowledge Distillation from Retrospectives
+
+## Session Metadata
+
+| Field | Value |
+|-------|-------|
+| Date | 2026-01-14 |
+| Time | 23:08 (Asia/Bangkok) |
+| Duration | ~30m |
+| Type | docs |
+| Status | completed |
+| Branch | knowledge/distill-patterns |
+| Issue | #24 |
+
+---
+
+## Context: Before
+
+- **Problem**: Learnings scattered across 6+ retrospectives
+- **Existing Behavior**: Same patterns repeated in multiple files
+- **Why Change**: Need centralized, searchable knowledge base
+- **Metrics**: 0 knowledge-base documents
+
+---
+
+## Context: After
+
+- **Solution**: Distilled patterns into 3 focused knowledge documents
+- **New Behavior**: Patterns documented with examples and anti-patterns
+- **Improvements**: Reusable reference for future development
+- **Metrics**: 3 knowledge-base documents (~530 lines)
+
+---
+
+## Test Results
+
+| Test | Status | Details |
+|------|--------|---------|
+| Knowledge documents created | ✅ | 3 files |
+| PR review passed | ✅ | 3 comments addressed |
+| Patterns are accurate | ✅ | Verified against source retrospectives |
+
+---
+
+## Decisions & Rationale
+
+| Decision | Options Considered | Chosen | Rationale |
+|----------|-------------------|--------|-----------|
+| Topics to distill | All patterns vs Top 3 | Top 3 | Most frequently repeated |
+| Document structure | Simple vs Full template | Full template | Consistent with existing patterns |
+
+---
+
+## Session Summary
+
+### Task Description
+Distill knowledge from retrospectives into reusable knowledge base documents
+
+### Outcome
+Created 3 knowledge-base documents:
+1. `heredoc-quoting.md` - Shell scripting safety
+2. `git-workflow-patterns.md` - Git best practices
+3. `github-api-patterns.md` - API usage patterns
+
+---
+
+## Technical Details
+
+### Files Created
+
+| File | Lines | Topic |
+|------|-------|-------|
+| `heredoc-quoting.md` | ~160 | <<'EOF' vs <<EOF |
+| `git-workflow-patterns.md` | ~180 | Stash, branch, push |
+| `github-api-patterns.md` | ~190 | GraphQL vs REST |
+
+### Recent Commits
+
+```
+42da6b7 fix: address PR review comments
+d994c0e knowledge: distill patterns from retrospectives
+```
+
+---
+
+## Honest Feedback
+
+### What Went Well
+- Pattern extraction was straightforward
+- Copilot review caught real issues (misleading comment)
+- Knowledge documents are comprehensive
+
+### What Could Be Improved
+- Could automate pattern detection in retrospectives
+- Consider adding search/index for knowledge-base
+
+---
+
+## Lessons Learned
+
+- **UUOC (Useless Use of Cat)**: `cat file | cmd` should be `cmd < file`
+- **Documentation clarity**: Comments must match code examples exactly
+- **Distill timing**: 3+ retrospectives on same topic = time to distill
+
+---
+
+## Validation Checklist
+
+- [x] Acceptance criteria met
+- [x] Documentation created
+- [x] PR created (#43)
+- [x] PR review addressed


### PR DESCRIPTION
## Summary

Session documentation for knowledge distillation task.

## Changes

- `docs/current.md` - Updated status
- `docs/logs/activity.log` - Added session entry
- `docs/retrospective/2026-01/retrospective_2026-01-14_230857.md` - Session retrospective

## Session Highlights

- Distilled 3 knowledge-base documents from 6 retrospectives
- Addressed PR #43 review comments (3 fixes)
- Knowledge base: heredoc-quoting, git-workflow, github-api patterns

## Related

- Issue: #24
- Knowledge PR: #43 (merged)