### PR TITLE
feat: add Decision Rationale section to /distill template

### DIFF
--- a/.claude/commands/distill.md
+++ b/.claude/commands/distill.md
@@ -78,6 +78,32 @@ description: Extract patterns from learnings into knowledge base
 
 ---
 
+## Decision Rationale (Optional)
+
+> ใช้เมื่อ knowledge นี้เกี่ยวข้องกับการตัดสินใจสำคัญ
+
+### Decision
+
+[สรุปการตัดสินใจ]
+
+### Alternatives Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| Option A | ... | ... |
+| **Chosen** ✓ | ... | ... |
+
+### Why This Choice?
+
+- เหตุผล 1
+- เหตุผล 2
+
+### Trade-offs Accepted
+
+- ยอมรับ X เพื่อได้ Y
+
+---
+
 ## Related
 
 - Learnings: source files

--- a/assets/commands/distill.md
+++ b/assets/commands/distill.md
@@ -78,6 +78,32 @@ description: Extract patterns from learnings into knowledge base
 
 ---
 
+## Decision Rationale (Optional)
+
+> ใช้เมื่อ knowledge นี้เกี่ยวข้องกับการตัดสินใจสำคัญ
+
+### Decision
+
+[สรุปการตัดสินใจ]
+
+### Alternatives Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| Option A | ... | ... |
+| **Chosen** ✓ | ... | ... |
+
+### Why This Choice?
+
+- เหตุผล 1
+- เหตุผล 2
+
+### Trade-offs Accepted
+
+- ยอมรับ X เพื่อได้ Y
+
+---
+
 ## Related
 
 - Learnings: source files

--- a/references/distill-template.md
+++ b/references/distill-template.md
@@ -63,6 +63,35 @@ docs/knowledge-base/[topic-name].md
 
 ---
 
+## Decision Rationale (Optional)
+
+> ใช้เมื่อ knowledge นี้เกี่ยวข้องกับการตัดสินใจสำคัญ เช่น architecture decisions, technology choices
+
+### Decision
+
+[สรุปการตัดสินใจที่ทำ]
+
+### Alternatives Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| Option A | ข้อดี | ข้อเสีย |
+| Option B | ข้อดี | ข้อเสีย |
+| **Chosen** ✓ | ข้อดีที่ชนะ | ข้อเสียที่ยอมรับได้ |
+
+### Why This Choice?
+
+- เหตุผลหลักที่เลือกทางนี้
+- ข้อได้เปรียบเทียบกับทางเลือกอื่น
+- Constraints ที่มีผลต่อการตัดสินใจ
+
+### Trade-offs Accepted
+
+- ยอมรับ [ข้อเสีย X] เพื่อได้ [ข้อดี Y]
+- [ข้อจำกัด] ที่ต้องอยู่ด้วย
+
+---
+
 ## Related
 
 - Learnings: `docs/learnings/...` (source files)


### PR DESCRIPTION
## Summary

Add optional "Decision Rationale" section to `/distill` template for documenting architecture decisions alongside patterns.

## Problem

Currently knowledge-base (`/distill`) focuses on patterns and solutions but lacks a place to record:
- Why a particular approach was chosen
- Alternatives that were considered
- Trade-offs that were accepted

This forces creation of separate ADR (Architecture Decision Records), which is redundant.

## Solution

Added optional "Decision Rationale" section with:
- **Decision** - Summary of the decision made
- **Alternatives Considered** - Table comparing options with pros/cons
- **Why This Choice?** - Reasoning behind the decision
- **Trade-offs Accepted** - What was sacrificed for the chosen approach

## Changes

| File | Change |
|------|--------|
| `assets/commands/distill.md` | Added Decision Rationale section to template |
| `.claude/commands/distill.md` | Synced with assets |
| `references/distill-template.md` | Added detailed guidance for the section |

## Benefits

- No need for separate ADR system
- Patterns + decisions in one knowledge-base
- Reduced cognitive load - one place for all knowledge

Closes #28