### PR TITLE
feat: add auto-respond to PR poll daemon (#49)

### DIFF
--- a/.claude/commands/pr-poll.md
+++ b/.claude/commands/pr-poll.md
@@ -10,7 +10,8 @@ description: Manage PR review polling daemon for automatic notifications
 
 ```
 /pr-poll              # Show status
-/pr-poll start        # Start daemon
+/pr-poll start        # Start daemon (notification only)
+/pr-poll auto         # Start daemon with auto-respond (Claude handles reviews)
 /pr-poll stop         # Stop daemon
 /pr-poll check        # Check once (no daemon)
 ```
@@ -23,7 +24,10 @@ description: Manage PR review polling daemon for automatic notifications
 → แสดงสถานะ daemon
 
 **ถ้า `start`:**
-→ Start daemon
+→ Start daemon (notification only)
+
+**ถ้า `auto`:**
+→ Start daemon with auto-respond (Claude handles reviews automatically)
 
 **ถ้า `stop`:**
 → Stop daemon
@@ -44,7 +48,7 @@ description: Manage PR review polling daemon for automatic notifications
 - Tracked PRs
 - Last log entries
 
-#### Start Daemon
+#### Start Daemon (Notification Only)
 
 ```bash
 ./scripts/pr-review-poll-start.sh --interval 300
@@ -62,6 +66,42 @@ Log file: ~/.pr-review-poll.log
 To view logs: tail -f ~/.pr-review-poll.log
 To stop: ./pr-review-poll-stop.sh
 ```
+
+#### Start Daemon with Auto-Respond
+
+```bash
+# Get current working directory
+WORKING_DIR=$(pwd)
+
+# Start with auto-respond enabled
+./scripts/pr-review-poll-start.sh --interval 300 --auto-respond --working-dir "$WORKING_DIR"
+```
+
+**Options:**
+- `--auto-respond` - Enable automatic Claude CLI spawning
+- `--working-dir DIR` - Working directory for Claude (required with --auto-respond)
+
+**Output:**
+```
+✓ Daemon started (PID: 12345)
+🤖 Auto-respond: ENABLED
+📂 Working dir: /path/to/repo
+
+Log file: ~/.pr-review-poll.log
+To view logs: tail -f ~/.pr-review-poll.log
+To stop: ./pr-review-poll-stop.sh
+```
+
+**How Auto-Respond Works:**
+1. Daemon detects new PR review
+2. Spawns Claude CLI with `/pr-review` prompt
+3. Claude analyzes and responds to review feedback
+4. Log file created: `~/.pr-review-claude-{pr}-{timestamp}.log`
+
+**Important Notes:**
+- Requires `claude` CLI to be installed and in PATH
+- Uses `--dangerously-skip-permissions` for non-interactive execution
+- Each Claude session runs in background with separate log file
 
 #### Stop Daemon
 
@@ -131,14 +171,20 @@ To stop: ./pr-review-poll-stop.sh
 ## Examples
 
 ```bash
-# Start daemon with 5-minute interval (default)
+# Start daemon with 5-minute interval (default, notification only)
 /pr-poll start
+
+# Start with auto-respond - Claude handles reviews automatically
+/pr-poll auto
 
 # Start with 1-minute interval for active development
 ./scripts/pr-review-poll-start.sh --interval 60
 
-# Monitor specific repo
-./scripts/pr-review-poll-start.sh --repo owner/repo
+# Auto-respond with 1-minute interval
+./scripts/pr-review-poll-start.sh --interval 60 --auto-respond --working-dir "$(pwd)"
+
+# Monitor specific repo with auto-respond
+./scripts/pr-review-poll-start.sh --repo owner/repo --auto-respond --working-dir /path/to/repo
 
 # Quick check without starting daemon
 /pr-poll check

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -403,32 +403,39 @@ EOF
 )"
 ```
 
-### Step 5.5: Start PR Review Polling (Auto)
+### Step 5.5: Start PR Review Polling with Auto-Respond
 
-**Auto-start polling daemon เพื่อรับ notification เมื่อมี review:**
+**Auto-start polling daemon พร้อม auto-respond - Claude จะจัดการ review อัตโนมัติ:**
 
 ```bash
-# Get script directory (relative to skill location)
+# Get script directory and working directory
 SKILL_DIR="${HOME}/.claude/skills/claude-km-skill"
+WORKING_DIR="$(pwd)"
 
 # Check if daemon already running
 PID_FILE="${HOME}/.pr-review-poll.pid"
 if [[ -f "$PID_FILE" ]] && ps -p "$(cat "$PID_FILE")" > /dev/null 2>&1; then
     echo "✓ PR polling daemon already running"
 else
-    # Start polling daemon
+    # Start polling daemon with auto-respond
     if [[ -x "${SKILL_DIR}/scripts/pr-review-poll-start.sh" ]]; then
-        "${SKILL_DIR}/scripts/pr-review-poll-start.sh" --interval 300 2>/dev/null || true
-        echo "✓ Started PR review polling (5 min interval)"
-        echo "  You'll get notifications when reviews come in"
+        "${SKILL_DIR}/scripts/pr-review-poll-start.sh" \
+            --interval 300 \
+            --auto-respond \
+            --working-dir "$WORKING_DIR" 2>/dev/null || true
+        echo "✓ Started PR review polling with auto-respond (5 min interval)"
+        echo "  Claude will automatically handle reviews when they come in"
+        echo "  Working dir: $WORKING_DIR"
     fi
 fi
 ```
 
 **Note:**
-- Polling daemon จะแจ้งเตือนเมื่อมี review ใหม่
+- Polling daemon จะตรวจสอบ PR reviews ทุก 5 นาที
+- เมื่อมี review ใหม่ Claude CLI จะถูก spawn อัตโนมัติเพื่อ run `/pr-review`
 - ใช้ `/pr-poll stop` เพื่อหยุด daemon
 - ใช้ `/pr-poll status` เพื่อดูสถานะ
+- Log ของ Claude sessions: `~/.pr-review-claude-*.log`
 
 ### Step 6: Confirm
 
@@ -448,14 +455,21 @@ fi
 **Issue:** #[issue-number]
 **PR:** [pr-url]
 
-### Auto Notifications
+### Auto-Respond Active
 
-🔔 PR review polling is now active. You'll receive notifications when:
-- PR is **approved** (Glass sound)
-- **Changes requested** (Basso sound)
-- Reviewer **comments** (Ping sound)
+🤖 PR review polling with auto-respond is now active:
+- When reviewer **approves**: Notification (Glass sound)
+- When **changes requested**: Claude spawns `/pr-review` automatically
+- When reviewer **comments**: Claude spawns `/pr-review` automatically
 
-Use `/pr-poll stop` to disable notifications.
+Claude will automatically:
+1. Analyze review feedback
+2. Fix code issues
+3. Reply to comments
+4. Push changes
+
+Use `/pr-poll stop` to disable auto-respond.
+View Claude logs: `tail -f ~/.pr-review-claude-*.log`
 
 ### Important Reminders
 
@@ -464,10 +478,11 @@ Use `/pr-poll stop` to disable notifications.
 - ห้ามปิด issue เอง - จะปิดอัตโนมัติเมื่อ PR ถูก merge
 
 ### Next Steps
-1. รอ reviewer approve PR (จะได้รับ notification)
-2. แก้ไขตาม feedback (ถ้ามี) - ใช้ `/pr-review`
-3. ใช้ `/td` เพื่อสร้าง retrospective
-4. ใช้ `/focus` เพื่อเริ่มงานใหม่
+1. รอ reviewer approve PR (Claude จะจัดการ feedback อัตโนมัติ)
+2. ตรวจสอบ Claude logs: `tail -f ~/.pr-review-claude-*.log`
+3. ใช้ `/pr-review` ด้วยตนเองหากต้องการควบคุม
+4. ใช้ `/td` เพื่อสร้าง retrospective
+5. ใช้ `/focus` เพื่อเริ่มงานใหม่
 ```
 
 ## Flow Summary

--- a/README.md
+++ b/README.md
@@ -64,9 +64,10 @@ cp ~/.claude/skills/knowledge-management-skill/assets/commands/*.md .claude/comm
 | Command | Purpose | Usage |
 |---------|---------|-------|
 | `/commit` | Atomic commits (via TDG) | `/commit` |
-| `/pr` | Test + Build + Review + Create PR | `/pr` |
+| `/pr` | Test + Build + Review + Create PR + Auto-respond | `/pr` |
 | `/review` | Manual code review | `/review` |
 | `/pr-review` | ตอบ PR feedback | `/pr-review` |
+| `/pr-poll` | จัดการ PR review polling daemon | `/pr-poll start` / `/pr-poll auto` |
 | `/permission` | จัดการ permissions - pre-allow safe commands | `/permission suggest` |
 
 ### Knowledge Capture (4-Layer)
@@ -128,6 +129,15 @@ cp ~/.claude/skills/knowledge-management-skill/assets/commands/*.md .claude/comm
                     │  test + build       │
                     │  code review        │
                     │  create PR          │
+                    │  start auto-respond │
+                    └─────────────────────┘
+                               │
+                               ▼
+                    ┌─────────────────────┐
+                    │   [Auto-Respond]    │
+                    │  poll for reviews   │
+                    │  Claude handles     │
+                    │  feedback auto      │
                     └─────────────────────┘
                                │
                                ▼
@@ -308,7 +318,11 @@ claude-km-skill/
 │   ├── ai-capture.sh           # AI-powered capture
 │   ├── claude-wrap.sh          # Claude wrapper
 │   ├── notify.sh               # macOS notification script
-│   └── jira-client.sh          # Jira API client
+│   ├── jira-client.sh          # Jira API client
+│   ├── pr-review-poll.sh       # PR review polling daemon
+│   ├── pr-review-poll-start.sh # Start daemon
+│   ├── pr-review-poll-stop.sh  # Stop daemon
+│   └── pr-review-poll-status.sh # Daemon status
 ├── references/
 │   ├── mem-template.md         # Full /mem template
 │   ├── distill-template.md     # Full /distill template
@@ -330,6 +344,7 @@ claude-km-skill/
     │   ├── review.md
     │   ├── pr.md               # Create PR with tests & review
     │   ├── pr-review.md        # Handle PR review feedback
+    │   ├── pr-poll.md          # PR review polling daemon
     │   ├── permission.md       # Permission management
     │   └── jira.md             # Jira commands
     └── agents/                 # Subagent definitions
@@ -428,6 +443,43 @@ Fixes #issue_number
 | Code Review | Subagent | No critical issues |
 
 **Note:** `/pr` จะรันทุกขั้นตอนนี้ให้อัตโนมัติพร้อม update issue ทุก step
+
+### PR Review Auto-Respond
+
+หลังจาก `/pr` สร้าง PR เสร็จ จะ auto-start polling daemon ที่จัดการ reviews อัตโนมัติ:
+
+```
+/pr สร้าง PR เสร็จ
+        ↓
+Start PR Poll Daemon (--auto-respond)
+        ↓
+[รอ reviewer...]
+        ↓
+เมื่อมี review → Daemon ตรวจจับ
+        ↓
+Spawn Claude CLI → run /pr-review อัตโนมัติ
+        ↓
+แก้ code, reply comments, push changes
+```
+
+| Event | Action |
+|-------|--------|
+| PR Approved | Notification (Glass sound) |
+| Changes Requested | Claude auto-responds |
+| Reviewer Comments | Claude auto-responds |
+
+**Commands:**
+
+```bash
+# ดูสถานะ daemon
+/pr-poll status
+
+# หยุด auto-respond
+/pr-poll stop
+
+# ดู Claude logs
+tail -f ~/.pr-review-claude-*.log
+```
 
 ### Forbidden Actions
 

--- a/assets/commands/pr-poll.md
+++ b/assets/commands/pr-poll.md
@@ -10,7 +10,8 @@ description: Manage PR review polling daemon for automatic notifications
 
 ```
 /pr-poll              # Show status
-/pr-poll start        # Start daemon
+/pr-poll start        # Start daemon (notification only)
+/pr-poll auto         # Start daemon with auto-respond (Claude handles reviews)
 /pr-poll stop         # Stop daemon
 /pr-poll check        # Check once (no daemon)
 ```
@@ -23,7 +24,10 @@ description: Manage PR review polling daemon for automatic notifications
 → แสดงสถานะ daemon
 
 **ถ้า `start`:**
-→ Start daemon
+→ Start daemon (notification only)
+
+**ถ้า `auto`:**
+→ Start daemon with auto-respond (Claude handles reviews automatically)
 
 **ถ้า `stop`:**
 → Stop daemon
@@ -44,7 +48,7 @@ description: Manage PR review polling daemon for automatic notifications
 - Tracked PRs
 - Last log entries
 
-#### Start Daemon
+#### Start Daemon (Notification Only)
 
 ```bash
 ./scripts/pr-review-poll-start.sh --interval 300
@@ -62,6 +66,42 @@ Log file: ~/.pr-review-poll.log
 To view logs: tail -f ~/.pr-review-poll.log
 To stop: ./pr-review-poll-stop.sh
 ```
+
+#### Start Daemon with Auto-Respond
+
+```bash
+# Get current working directory
+WORKING_DIR=$(pwd)
+
+# Start with auto-respond enabled
+./scripts/pr-review-poll-start.sh --interval 300 --auto-respond --working-dir "$WORKING_DIR"
+```
+
+**Options:**
+- `--auto-respond` - Enable automatic Claude CLI spawning
+- `--working-dir DIR` - Working directory for Claude (required with --auto-respond)
+
+**Output:**
+```
+✓ Daemon started (PID: 12345)
+🤖 Auto-respond: ENABLED
+📂 Working dir: /path/to/repo
+
+Log file: ~/.pr-review-poll.log
+To view logs: tail -f ~/.pr-review-poll.log
+To stop: ./pr-review-poll-stop.sh
+```
+
+**How Auto-Respond Works:**
+1. Daemon detects new PR review
+2. Spawns Claude CLI with `/pr-review` prompt
+3. Claude analyzes and responds to review feedback
+4. Log file created: `~/.pr-review-claude-{pr}-{timestamp}.log`
+
+**Important Notes:**
+- Requires `claude` CLI to be installed and in PATH
+- Uses `--dangerously-skip-permissions` for non-interactive execution
+- Each Claude session runs in background with separate log file
 
 #### Stop Daemon
 
@@ -131,14 +171,20 @@ To stop: ./pr-review-poll-stop.sh
 ## Examples
 
 ```bash
-# Start daemon with 5-minute interval (default)
+# Start daemon with 5-minute interval (default, notification only)
 /pr-poll start
+
+# Start with auto-respond - Claude handles reviews automatically
+/pr-poll auto
 
 # Start with 1-minute interval for active development
 ./scripts/pr-review-poll-start.sh --interval 60
 
-# Monitor specific repo
-./scripts/pr-review-poll-start.sh --repo owner/repo
+# Auto-respond with 1-minute interval
+./scripts/pr-review-poll-start.sh --interval 60 --auto-respond --working-dir "$(pwd)"
+
+# Monitor specific repo with auto-respond
+./scripts/pr-review-poll-start.sh --repo owner/repo --auto-respond --working-dir /path/to/repo
 
 # Quick check without starting daemon
 /pr-poll check

--- a/assets/commands/pr.md
+++ b/assets/commands/pr.md
@@ -403,32 +403,39 @@ EOF
 )"
 ```
 
-### Step 5.5: Start PR Review Polling (Auto)
+### Step 5.5: Start PR Review Polling with Auto-Respond
 
-**Auto-start polling daemon เพื่อรับ notification เมื่อมี review:**
+**Auto-start polling daemon พร้อม auto-respond - Claude จะจัดการ review อัตโนมัติ:**
 
 ```bash
-# Get script directory (relative to skill location)
+# Get script directory and working directory
 SKILL_DIR="${HOME}/.claude/skills/claude-km-skill"
+WORKING_DIR="$(pwd)"
 
 # Check if daemon already running
 PID_FILE="${HOME}/.pr-review-poll.pid"
 if [[ -f "$PID_FILE" ]] && ps -p "$(cat "$PID_FILE")" > /dev/null 2>&1; then
     echo "✓ PR polling daemon already running"
 else
-    # Start polling daemon
+    # Start polling daemon with auto-respond
     if [[ -x "${SKILL_DIR}/scripts/pr-review-poll-start.sh" ]]; then
-        "${SKILL_DIR}/scripts/pr-review-poll-start.sh" --interval 300 2>/dev/null || true
-        echo "✓ Started PR review polling (5 min interval)"
-        echo "  You'll get notifications when reviews come in"
+        "${SKILL_DIR}/scripts/pr-review-poll-start.sh" \
+            --interval 300 \
+            --auto-respond \
+            --working-dir "$WORKING_DIR" 2>/dev/null || true
+        echo "✓ Started PR review polling with auto-respond (5 min interval)"
+        echo "  Claude will automatically handle reviews when they come in"
+        echo "  Working dir: $WORKING_DIR"
     fi
 fi
 ```
 
 **Note:**
-- Polling daemon จะแจ้งเตือนเมื่อมี review ใหม่
+- Polling daemon จะตรวจสอบ PR reviews ทุก 5 นาที
+- เมื่อมี review ใหม่ Claude CLI จะถูก spawn อัตโนมัติเพื่อ run `/pr-review`
 - ใช้ `/pr-poll stop` เพื่อหยุด daemon
 - ใช้ `/pr-poll status` เพื่อดูสถานะ
+- Log ของ Claude sessions: `~/.pr-review-claude-*.log`
 
 ### Step 6: Confirm
 
@@ -448,14 +455,21 @@ fi
 **Issue:** #[issue-number]
 **PR:** [pr-url]
 
-### Auto Notifications
+### Auto-Respond Active
 
-🔔 PR review polling is now active. You'll receive notifications when:
-- PR is **approved** (Glass sound)
-- **Changes requested** (Basso sound)
-- Reviewer **comments** (Ping sound)
+🤖 PR review polling with auto-respond is now active:
+- When reviewer **approves**: Notification (Glass sound)
+- When **changes requested**: Claude spawns `/pr-review` automatically
+- When reviewer **comments**: Claude spawns `/pr-review` automatically
 
-Use `/pr-poll stop` to disable notifications.
+Claude will automatically:
+1. Analyze review feedback
+2. Fix code issues
+3. Reply to comments
+4. Push changes
+
+Use `/pr-poll stop` to disable auto-respond.
+View Claude logs: `tail -f ~/.pr-review-claude-*.log`
 
 ### Important Reminders
 
@@ -464,10 +478,11 @@ Use `/pr-poll stop` to disable notifications.
 - ห้ามปิด issue เอง - จะปิดอัตโนมัติเมื่อ PR ถูก merge
 
 ### Next Steps
-1. รอ reviewer approve PR (จะได้รับ notification)
-2. แก้ไขตาม feedback (ถ้ามี) - ใช้ `/pr-review`
-3. ใช้ `/td` เพื่อสร้าง retrospective
-4. ใช้ `/focus` เพื่อเริ่มงานใหม่
+1. รอ reviewer approve PR (Claude จะจัดการ feedback อัตโนมัติ)
+2. ตรวจสอบ Claude logs: `tail -f ~/.pr-review-claude-*.log`
+3. ใช้ `/pr-review` ด้วยตนเองหากต้องการควบคุม
+4. ใช้ `/td` เพื่อสร้าง retrospective
+5. ใช้ `/focus` เพื่อเริ่มงานใหม่
 ```
 
 ## Flow Summary

--- a/docs/current.md
+++ b/docs/current.md
@@ -1,4 +1,4 @@
 STATE: completed
-TASK: Auto-assign issue when starting work
-SINCE: 2026-01-15 01:10
+TASK: PR Poll Auto-Respond Feature
+SINCE: 2026-01-15 19:31
 ISSUE: #49

--- a/docs/logs/activity.log
+++ b/docs/logs/activity.log
@@ -28,3 +28,4 @@
 2026-01-15 00:46 | completed | Add PR review polling daemon #48
 2026-01-15 00:49 | started | Auto-assign issue when starting work #49
 2026-01-15 01:10 | completed | Auto-assign issue + workflow automation #49
+2026-01-15 19:31 | completed | PR Poll Auto-Respond Feature

--- a/docs/retrospective/2026-01/retrospective_2026-01-15_192930.md
+++ b/docs/retrospective/2026-01/retrospective_2026-01-15_192930.md
@@ -1,0 +1,145 @@
+---
+date: 2026-01-15T19:29:30+07:00
+type: feature
+status: completed
+tags: [pr-poll, auto-respond, daemon, claude-cli]
+branch: main
+issue: "#49"
+duration: ~1h
+files_changed:
+  - scripts/pr-review-poll.sh
+  - scripts/pr-review-poll-start.sh
+  - .claude/commands/pr-poll.md
+  - .claude/commands/pr.md
+  - README.md
+  - assets/commands/pr-poll.md
+  - assets/commands/pr.md
+---
+
+# PR Poll Auto-Respond Feature
+
+## Session Metadata
+
+| Field | Value |
+|-------|-------|
+| Date | 2026-01-15 |
+| Time | 19:29:30 (Asia/Bangkok) |
+| Duration | ~1h |
+| Type | feature |
+| Status | completed |
+| Branch | main |
+| Issue | #49 |
+
+---
+
+## Context: Before
+
+- **Problem**: หลัง `/pr` สร้าง PR เสร็จ ต้องรอ notification แล้ว run `/pr-review` ด้วยตัวเอง
+- **Existing Behavior**: pr-poll daemon ส่ง macOS notification แจ้งเตือน แต่ไม่ทำอะไรต่อ
+- **Why Change**: ต้องการให้ระบบจัดการ PR review อัตโนมัติโดยไม่ต้องรอ user
+- **Metrics**: ต้อง manual run `/pr-review` ทุกครั้งที่มี review
+
+---
+
+## Context: After
+
+- **Solution**: เพิ่ม `--auto-respond` flag ให้ daemon spawn Claude CLI อัตโนมัติ
+- **New Behavior**: เมื่อมี PR review daemon จะ spawn `claude --print --dangerously-skip-permissions` เพื่อ run `/pr-review`
+- **Improvements**: ลดการ manual intervention หลัง PR
+- **Metrics**: Zero manual action required (ยกเว้นกรณีพิเศษ)
+
+---
+
+## Test Results
+
+| Test | Status | Details |
+|------|--------|---------|
+| Bash Syntax Check | ✅ | `bash -n pr-review-poll.sh` passed |
+| Manual Flow Test | ⏳ | รอ PR review มาทดสอบจริง |
+
+---
+
+## Decisions & Rationale
+
+| Decision | Options Considered | Chosen | Rationale |
+|----------|-------------------|--------|-----------|
+| Skip permissions | Interactive, Skip | `--dangerously-skip-permissions` | Daemon ต้องทำงาน non-interactive |
+| Working dir | Hardcode, Parameter | `--working-dir` flag | Flexibility สำหรับ multiple projects |
+| Integration | Separate command, Integrated | Integrated with `/pr` | Seamless workflow |
+
+---
+
+## Session Summary
+
+### Task Description
+เพิ่ม auto-respond feature ให้ pr-poll daemon เพื่อให้ Claude จัดการ PR review อัตโนมัติ
+
+### Outcome
+- Daemon รองรับ `--auto-respond` และ `--working-dir` flags
+- `/pr` auto-start daemon หลังสร้าง PR
+- Documentation อัพเดตเรียบร้อย
+
+---
+
+## Technical Details
+
+### Files Modified
+
+| File | Changes |
+|------|---------|
+| `scripts/pr-review-poll.sh` | เพิ่ม `spawn_claude_pr_review()`, `--auto-respond`, `--working-dir` |
+| `scripts/pr-review-poll-start.sh` | อัพเดต help และ examples |
+| `.claude/commands/pr-poll.md` | เพิ่ม auto mode documentation |
+| `.claude/commands/pr.md` | ปรับ Step 5.5 ใช้ auto-respond |
+| `README.md` | เพิ่ม PR Review Auto-Respond section |
+
+### Key Code Added
+
+```bash
+# Spawn Claude CLI to handle PR review
+spawn_claude_pr_review() {
+    local pr_number="$1"
+    local pr_title="$2"
+    local reviewer="$3"
+    local review_state="$4"
+
+    local log_file="${HOME}/.pr-review-claude-${pr_number}-$(date '+%Y%m%d-%H%M%S').log"
+    local prompt="Review feedback received on PR #${pr_number}..."
+
+    (
+        cd "$WORKING_DIR"
+        claude --print --dangerously-skip-permissions "$prompt" >> "$log_file" 2>&1
+    ) &
+}
+```
+
+---
+
+## Honest Feedback
+
+### What Went Well
+- Clear flow design ตั้งแต่ต้น
+- Incremental implementation ทีละ step
+- Documentation updated ครบถ้วน
+
+### What Could Be Improved
+- ยังไม่ได้ทดสอบ flow จริงกับ PR review
+- อาจต้องเพิ่ม retry logic ถ้า Claude fail
+
+---
+
+## Lessons Learned
+
+- Claude CLI มี `--print` และ `--dangerously-skip-permissions` สำหรับ non-interactive use
+- Background process ใน bash ต้องใช้ subshell `()` เพื่อ isolate working directory
+- Log file แยกต่อ session ช่วย debug ได้ง่าย
+
+---
+
+## Validation Checklist
+
+- [x] Auto-respond flag implemented
+- [x] Working dir validation
+- [x] Integration with /pr
+- [x] Documentation updated
+- [ ] Full flow test (pending PR review)

--- a/scripts/pr-review-poll-start.sh
+++ b/scripts/pr-review-poll-start.sh
@@ -3,9 +3,11 @@
 #
 # Usage: ./pr-review-poll-start.sh [options]
 # Options:
-#   --interval N     Polling interval in seconds (default: 300)
+#   --interval N       Polling interval in seconds (default: 300)
 #   --repo OWNER/REPO  Specific repo to monitor
-#   -h, --help       Show this help message
+#   --auto-respond     Auto-spawn Claude CLI to handle reviews
+#   --working-dir DIR  Working directory for Claude (required with --auto-respond)
+#   -h, --help         Show this help message
 
 set -euo pipefail
 
@@ -27,13 +29,22 @@ Start PR Review Polling Daemon
 Usage: ./pr-review-poll-start.sh [options]
 
 Options:
-  --interval N       Polling interval in seconds (default: 300 = 5 minutes)
-  --repo OWNER/REPO  Specific repo to monitor
-  -h, --help         Show this help message
+  --interval N         Polling interval in seconds (default: 300 = 5 minutes)
+  --repo OWNER/REPO    Specific repo to monitor
+  --auto-respond       Auto-spawn Claude CLI to handle reviews
+  --working-dir DIR    Working directory for Claude (required with --auto-respond)
+  -h, --help           Show this help message
 
 Files:
   PID file: $PID_FILE
   Log file: $LOG_FILE
+
+Examples:
+  # Basic polling with notifications only
+  ./pr-review-poll-start.sh --interval 60
+
+  # Auto-respond mode - Claude handles reviews automatically
+  ./pr-review-poll-start.sh --auto-respond --working-dir /path/to/repo
 
 EOF
 }

--- a/scripts/pr-review-poll.sh
+++ b/scripts/pr-review-poll.sh
@@ -15,6 +15,8 @@ set -euo pipefail
 POLL_INTERVAL=300  # 5 minutes
 RUN_ONCE=false
 REPO=""
+AUTO_RESPOND=false
+WORKING_DIR=""
 STATE_FILE="${HOME}/.pr-review-state.json"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
@@ -50,6 +52,8 @@ Options:
   --interval N       Polling interval in seconds (default: 300 = 5 minutes)
   --once             Run once and exit (useful for testing)
   --repo OWNER/REPO  Specific repo to monitor (default: current directory's repo)
+  --auto-respond     Automatically spawn Claude CLI to handle reviews
+  --working-dir DIR  Working directory for Claude CLI (required with --auto-respond)
   -h, --help         Show this help message
 
 State:
@@ -79,6 +83,14 @@ while [[ $# -gt 0 ]]; do
             REPO="$2"
             shift 2
             ;;
+        --auto-respond)
+            AUTO_RESPOND=true
+            shift
+            ;;
+        --working-dir)
+            WORKING_DIR="$2"
+            shift 2
+            ;;
         -h|--help)
             show_help
             exit 0
@@ -90,6 +102,22 @@ while [[ $# -gt 0 ]]; do
             ;;
     esac
 done
+
+# Validate auto-respond requirements
+if [[ "$AUTO_RESPOND" == "true" ]]; then
+    if [[ -z "$WORKING_DIR" ]]; then
+        echo -e "${RED}Error: --working-dir is required when using --auto-respond${NC}"
+        exit 1
+    fi
+    if [[ ! -d "$WORKING_DIR" ]]; then
+        echo -e "${RED}Error: Working directory does not exist: $WORKING_DIR${NC}"
+        exit 1
+    fi
+    if ! command -v claude &> /dev/null; then
+        echo -e "${RED}Error: Claude CLI not found. Please install Claude Code.${NC}"
+        exit 1
+    fi
+fi
 
 # Get repo from git if not specified
 if [[ -z "$REPO" ]]; then
@@ -104,6 +132,49 @@ fi
 if [[ ! -f "$STATE_FILE" ]]; then
     echo '{}' > "$STATE_FILE"
 fi
+
+# Spawn Claude CLI to handle PR review
+spawn_claude_pr_review() {
+    local pr_number="$1"
+    local pr_title="$2"
+    local reviewer="$3"
+    local review_state="$4"
+
+    echo -e "${GREEN}[$(date '+%H:%M:%S')]${NC} Spawning Claude CLI for PR #$pr_number..."
+
+    # Create log file for this session
+    local log_file="${HOME}/.pr-review-claude-${pr_number}-$(date '+%Y%m%d-%H%M%S').log"
+
+    # Build the prompt
+    local prompt="Review feedback received on PR #${pr_number} from @${reviewer} (${review_state}). Please run /pr-review ${pr_number} to analyze and respond to the feedback."
+
+    # Spawn Claude CLI in the working directory
+    # Using nohup to run in background, output to log file
+    (
+        cd "$WORKING_DIR"
+        echo "=== Claude PR Review Session ===" > "$log_file"
+        echo "PR: #$pr_number - $pr_title" >> "$log_file"
+        echo "Reviewer: @$reviewer" >> "$log_file"
+        echo "State: $review_state" >> "$log_file"
+        echo "Started: $(date)" >> "$log_file"
+        echo "Working Dir: $WORKING_DIR" >> "$log_file"
+        echo "================================" >> "$log_file"
+        echo "" >> "$log_file"
+
+        # Run Claude CLI with the prompt
+        # --print outputs result without interactive mode
+        # --dangerously-skip-permissions to avoid blocking on permission prompts
+        claude --print --dangerously-skip-permissions "$prompt" >> "$log_file" 2>&1
+
+        echo "" >> "$log_file"
+        echo "=== Session Complete ===" >> "$log_file"
+        echo "Ended: $(date)" >> "$log_file"
+    ) &
+
+    local claude_pid=$!
+    echo -e "${GREEN}[$(date '+%H:%M:%S')]${NC} Claude spawned (PID: $claude_pid)"
+    echo -e "${BLUE}[$(date '+%H:%M:%S')]${NC} Log file: $log_file"
+}
 
 # Send notification
 send_notification() {
@@ -159,6 +230,11 @@ send_notification() {
     fi
 
     echo -e "${GREEN}[$(date '+%H:%M:%S')]${NC} Notified: PR #$pr_number - $review_state by @$reviewer"
+
+    # Auto-respond if enabled
+    if [[ "$AUTO_RESPOND" == "true" ]]; then
+        spawn_claude_pr_review "$pr_number" "$pr_title" "$reviewer" "$review_state"
+    fi
 }
 
 # Get state for a PR
@@ -279,6 +355,12 @@ main() {
     echo -e "📦 Repository: ${GREEN}$REPO${NC}"
     echo -e "⏱️  Interval: ${GREEN}${POLL_INTERVAL}s${NC}"
     echo -e "📁 State file: ${GREEN}$STATE_FILE${NC}"
+    if [[ "$AUTO_RESPOND" == "true" ]]; then
+        echo -e "🤖 Auto-respond: ${GREEN}ENABLED${NC}"
+        echo -e "📂 Working dir: ${GREEN}$WORKING_DIR${NC}"
+    else
+        echo -e "🤖 Auto-respond: ${YELLOW}DISABLED${NC}"
+    fi
     echo ""
 
     if [[ "$RUN_ONCE" == "true" ]]; then


### PR DESCRIPTION
## Summary

Add auto-respond feature to PR poll daemon. When enabled, Claude CLI is automatically spawned to handle PR reviews.

## Changes

- Add `--auto-respond` and `--working-dir` flags to `pr-review-poll.sh`
- Add `spawn_claude_pr_review()` function to spawn Claude CLI
- Update `/pr` to start auto-respond daemon after PR creation
- Update `pr-poll.md` documentation with auto mode
- Update `README.md` with PR Review Auto-Respond section

## How It Works

```
/pr creates PR
       ↓
Start PR Poll Daemon (--auto-respond)
       ↓
[Wait for reviewer...]
       ↓
When review detected → Daemon spawns Claude CLI
       ↓
Claude runs /pr-review automatically
       ↓
Fix code, reply comments, push changes
```

## Usage

```bash
# Auto mode (via /pr - default after PR creation)
/pr-poll auto

# Manual start with auto-respond
./scripts/pr-review-poll-start.sh --auto-respond --working-dir "$(pwd)"

# Check logs
tail -f ~/.pr-review-claude-*.log
```

## Testing

- [x] Bash syntax check passed
- [ ] Full flow test (pending actual PR review)

## Related Issues

Fixes #49