### PR TITLE
fix: handle JSON array format from gh CLI in PR polling

### DIFF
--- a/scripts/pr-review-poll.sh
+++ b/scripts/pr-review-poll.sh
@@ -407,7 +407,11 @@ check_prs() {
 
     # Get list of open PR numbers for cleanup
     local open_pr_numbers
-    open_pr_numbers=$(echo "$prs" | jq -r '.number' | tr '\n' ',' | sed 's/,$//')
+    open_pr_numbers=$(echo "$prs" | jq -r 'if type == "array" then .[].number else .number end' | tr '\n' ',' | sed 's/,$//')
+
+    # Normalize prs to newline-separated JSON objects
+    local prs_normalized
+    prs_normalized=$(echo "$prs" | jq -c 'if type == "array" then .[] else . end')
 
     # Process each PR (use process substitution to avoid subshell)
     while read -r pr; do
@@ -497,7 +501,7 @@ check_prs() {
 
             update_pr_state "$pr_number" "$latest_review_id" "$comment_count" "$review_decision" "$copilot_pending"
         fi
-    done < <(echo "$prs" | jq -c '.')
+    done < <(echo "$prs_normalized")
 
     # Cleanup state for closed PRs
     if [[ -n "$open_pr_numbers" ]]; then


### PR DESCRIPTION
## Summary

Normalize jq parsing in `check_prs()` to support both JSON array and newline-delimited JSON object formats returned by different `gh` CLI commands, preventing parse errors.

## Changes Made

- scripts/pr-review-poll.sh

## Problem

The `check_prs` function can receive PR data in two formats:
- **Primary path** (`gh api`): newline-separated JSON objects
- **Fallback path** (`gh pr list`): JSON array (`[{...}, {...}]`)

The original code assumed a single format, causing parse failures when the fallback path was used.

## Fix

- Added type-checking in jq expressions to handle both array and object inputs
- Introduced `prs_normalized` variable to normalize data once and reuse downstream
- Changed loop input to use pre-normalized data instead of re-parsing

## Testing

- Manual verification with both JSON formats
- Code review passed (no critical issues)