### PR TITLE
docs: session retrospective for #78

### DIFF
--- a/docs/current.md
+++ b/docs/current.md
@@ -1,5 +1,4 @@
-STATE: working
-TASK: Fix jira-client.sh init command for non-interactive environments
-SINCE: 2026-01-23 14:52
-ISSUE: #73
-BRANCH: fix/73-jira-init-non-interactive
+STATE: completed
+TASK: Fix JSON array format handling in PR polling
+SINCE: 2026-01-23 15:24
+ISSUE: #78

--- a/docs/logs/activity.log
+++ b/docs/logs/activity.log
@@ -39,3 +39,4 @@
 2026-01-22 23:08 | working | Usage documentation for skill system (#67)
 2026-01-22 23:29 | completed | Usage documentation #67 - PR #68 merged
 2026-01-23 14:52 | working | Fix jira-client.sh init for non-interactive environments (#73)
+2026-01-23 15:25 | completed | Fix JSON array format handling in PR polling (#78)

--- a/docs/retrospective/2026-01/retrospective_2026-01-23_152435.md
+++ b/docs/retrospective/2026-01/retrospective_2026-01-23_152435.md
@@ -1,0 +1,117 @@
+---
+date: 2026-01-23T15:24:35+07:00
+type: bugfix
+status: completed
+tags: [pr-polling, jq, json-parsing, gh-cli]
+branch: fix/pr-poll-json-array-handling
+issue: "#78"
+duration: ~30m
+files_changed:
+  - scripts/pr-review-poll.sh
+---
+
+# Fix JSON Array Format Handling in PR Polling
+
+## Session Metadata
+
+| Field | Value |
+|-------|-------|
+| Date | 2026-01-23 |
+| Time | 15:24:35 (Asia/Bangkok) |
+| Duration | ~30m |
+| Type | bugfix |
+| Status | completed |
+| Branch | fix/pr-poll-json-array-handling |
+| Issue | #78 |
+
+---
+
+## Context: Before
+
+- **Problem**: `check_prs()` function in `pr-review-poll.sh` assumed PR data was always in newline-delimited JSON object format
+- **Existing Behavior**: When `gh pr list` fallback was used (returns JSON array `[{...}]`), jq parsing failed silently or produced incorrect results
+- **Why Change**: The script has two code paths for fetching PRs - `gh api` (returns newline-delimited objects) and `gh pr list` (returns JSON array) - both need to work correctly
+- **Metrics**: PR polling could miss PRs or error out when fallback path was triggered
+
+---
+
+## Context: After
+
+- **Solution**: Added type-checking in jq expressions and normalized input to consistent format before processing
+- **New Behavior**: Both JSON array and newline-delimited object formats are handled correctly
+- **Improvements**: Single normalization step (`prs_normalized`) avoids redundant parsing in the loop
+- **Metrics**: PR polling works correctly regardless of which `gh` command provides the data
+
+---
+
+## Test Results
+
+| Test | Status | Details |
+|------|--------|---------|
+| Code Review | ✅ | No critical issues found |
+| Manual Verification | ✅ | Both JSON formats handled correctly |
+
+---
+
+## Decisions & Rationale
+
+| Decision | Options Considered | Chosen | Rationale |
+|----------|-------------------|--------|-----------|
+| Normalization approach | Fix each jq call individually vs. normalize once | Normalize once into `prs_normalized` | DRY - single normalization reused downstream |
+| Type detection | Check variable format before loop vs. jq type checking | jq `if type == "array"` | More robust, handles edge cases within jq itself |
+
+---
+
+## Session Summary
+
+### Task Description
+Fix a bug in `scripts/pr-review-poll.sh` where the `check_prs()` function could not properly parse PR data when it came as a JSON array (from `gh pr list` fallback) instead of newline-delimited JSON objects (from `gh api`).
+
+### Outcome
+Bug fixed, PR #78 created, reviewed, and merged to main.
+
+---
+
+## Technical Details
+
+### Files Modified
+
+| File | Changes |
+|------|---------|
+| `scripts/pr-review-poll.sh` | Added jq type-checking for array/object, introduced `prs_normalized` variable, updated loop input |
+
+### Recent Commits
+
+```
+2cfeed6 Merge pull request #78 from goffity/fix/pr-poll-json-array-handling
+b5a8395 fix: handle JSON array format from gh CLI in PR polling
+```
+
+---
+
+## Honest Feedback
+
+### What Went Well
+- Quick identification and fix of the issue
+- Clean atomic commit with clear message
+- Code review passed without critical issues
+
+### What Could Be Improved
+- Initially committed directly to main before creating feature branch (had to reset main after)
+- No automated tests for shell scripts - could add test harness in future
+
+---
+
+## Lessons Learned
+
+- `gh api` with `--jq` filter produces newline-delimited objects, while `gh pr list --json` produces a JSON array - always normalize format when both paths exist
+- When working on main, create the feature branch first before committing
+
+---
+
+## Validation Checklist
+
+- [x] Acceptance criteria met
+- [x] Code review passed
+- [x] PR created and merged (#78)
+- [ ] Documentation updated (not needed for this fix)


### PR DESCRIPTION
## Summary

Session documentation update for PR #78 (fix JSON array format handling in PR polling)

## Changes

- Updated `docs/current.md` status
- Added activity log entry
- Created retrospective: `docs/retrospective/2026-01/retrospective_2026-01-23_152435.md`

## Related

- PR: #78 (merged)