### PR TITLE
fix: validate and sanitize JIRA_DOMAIN format

### DIFF
--- a/scripts/jira-client.sh
+++ b/scripts/jira-client.sh
@@ -94,6 +94,18 @@ validate_config() {
         echo "Run: jira-client.sh init" >&2
         return 1
     fi
+
+    # Sanitize JIRA_DOMAIN: strip protocol and trailing slash
+    JIRA_DOMAIN="${JIRA_DOMAIN#https://}"
+    JIRA_DOMAIN="${JIRA_DOMAIN#http://}"
+    JIRA_DOMAIN="${JIRA_DOMAIN%/}"
+
+    # Validate domain format
+    if [[ ! "$JIRA_DOMAIN" =~ ^[A-Za-z0-9-]+(\.[A-Za-z0-9-]+)+$ ]]; then
+        echo "Error: Invalid JIRA_DOMAIN format: $JIRA_DOMAIN" >&2
+        echo "Expected: company.atlassian.net (without https://)" >&2
+        return 1
+    fi
 }
 
 # Base URL for API calls


### PR DESCRIPTION
## Summary

Add domain sanitization and format validation in `validate_config()` to prevent malformed API URLs when users include protocol prefix in JIRA_DOMAIN.

## Problem

If a user sets `JIRA_DOMAIN=https://company.atlassian.net`, the API URL becomes `https://https://company.atlassian.net/rest/api/3/...` causing cryptic DNS resolution errors.

## Fix

- Strip `https://` and `http://` prefixes from JIRA_DOMAIN
- Strip trailing slash
- Validate domain format matches expected pattern
- Provide clear error message if format is invalid

## Changes

- scripts/jira-client.sh

Fixes #72