### PR TITLE
fix: add new commands to .claude/commands for discovery

### DIFF
--- a/.claude/commands/example.md
+++ b/.claude/commands/example.md
@@ -1,0 +1,112 @@
+---
+description: Save reusable code examples to the examples library
+---
+
+# Example - Code Examples Library
+
+Save and organize reusable code snippets with metadata.
+
+## Usage
+
+```
+/example [language] [name]
+```
+
+**Output:** `$PROJECT_ROOT/docs/examples/[language]/[name].[ext]`
+
+## Instructions
+
+1. **Parse arguments**: language (go, typescript, python, bash, etc.) and name (kebab-case)
+2. **Determine file extension** from language:
+   - go → .go
+   - typescript/ts → .ts
+   - javascript/js → .js
+   - python/py → .py
+   - bash/sh → .sh
+   - rust → .rs
+   - java → .java
+3. **Gather context**: Look at recent code in conversation, ask user what code to save if unclear
+4. **Create directory**: `docs/examples/[language]/`
+5. **Generate file** with metadata header and code
+6. **Confirm** with user
+
+## File Format
+
+### Go Example
+```go
+// Title: [Descriptive Title]
+// Tags: [tag1, tag2, tag3]
+// Related: [link to knowledge-base or learnings if any]
+// Created: YYYY-MM-DD
+
+package examples
+
+// [Description of what this code does]
+// Usage:
+//   [usage example]
+[code]
+```
+
+### TypeScript/JavaScript Example
+```typescript
+// Title: [Descriptive Title]
+// Tags: [tag1, tag2, tag3]
+// Related: [link to knowledge-base if any]
+// Created: YYYY-MM-DD
+
+// [Description]
+// Usage:
+//   [usage example]
+[code]
+```
+
+### Python Example
+```python
+# Title: [Descriptive Title]
+# Tags: [tag1, tag2, tag3]
+# Related: [link to knowledge-base if any]
+# Created: YYYY-MM-DD
+
+# [Description]
+# Usage:
+#   [usage example]
+[code]
+```
+
+### Bash Example
+```bash
+#!/bin/bash
+# Title: [Descriptive Title]
+# Tags: [tag1, tag2, tag3]
+# Related: [link to knowledge-base if any]
+# Created: YYYY-MM-DD
+
+# [Description]
+# Usage:
+#   [usage example]
+[code]
+```
+
+## Guidelines
+
+- Code should be **runnable** or at minimum compilable
+- Include usage examples in comments
+- Add relevant tags for searchability
+- Link to related knowledge-base entries if they exist
+- Keep examples focused on one concept/pattern
+- Use descriptive names (e.g., `retry-with-backoff`, `api-client-wrapper`)
+
+## Listing Examples
+
+To browse existing examples:
+```bash
+find docs/examples -type f | sort
+```
+
+## Related Commands
+
+| Command | Purpose |
+|---------|---------|
+| `/mem` | Quick knowledge capture |
+| `/distill` | Extract patterns to knowledge base |
+| `/example` | Save code examples (you are here) |

--- a/.claude/commands/flow.md
+++ b/.claude/commands/flow.md
@@ -1,0 +1,106 @@
+---
+description: Document workflow diagrams and process flows with Mermaid support
+---
+
+# Flow - Process Flow Documentation
+
+Document workflows, sequences, and state machines with Mermaid diagrams.
+
+## Usage
+
+```
+/flow [name]
+/flow pr-review
+/flow deployment
+```
+
+**Output:** `$PROJECT_ROOT/docs/flows/[name].md`
+
+## Instructions
+
+1. **Parse name** → kebab-case filename
+2. **Ask user** about the flow:
+   - What type? (process/sequence/state)
+   - What actors/components are involved?
+   - What are the main steps?
+3. **Generate** flow document with Mermaid diagram
+4. **Save** to `docs/flows/[name].md`
+
+## Template
+
+```markdown
+# [Flow Name]
+
+| Field | Value |
+|-------|-------|
+| Type | Process / Sequence / State |
+| Actors | [list of actors] |
+| Created | YYYY-MM-DD |
+
+## Overview
+
+> One sentence description of what this flow does.
+
+## Diagram
+
+```mermaid
+sequenceDiagram
+    participant A as Actor1
+    participant B as Actor2
+
+    A->>B: Action
+    B-->>A: Response
+```
+
+## Steps
+
+1. **Step 1**: Description
+2. **Step 2**: Description
+3. **Step 3**: Description
+
+## Error Handling
+
+| Error | Handling |
+|-------|----------|
+| [error case] | [how to handle] |
+
+## Related
+
+- [related flows or docs]
+```
+
+## Diagram Types
+
+### Sequence Diagram
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant S as System
+    U->>S: Request
+    S-->>U: Response
+```
+
+### Flowchart
+```mermaid
+flowchart TD
+    A[Start] --> B{Decision}
+    B -->|Yes| C[Action]
+    B -->|No| D[Other]
+```
+
+### State Diagram
+```mermaid
+stateDiagram-v2
+    [*] --> Idle
+    Idle --> Processing: start
+    Processing --> Done: complete
+    Processing --> Error: fail
+```
+
+## Related Commands
+
+| Command | Purpose |
+|---------|---------|
+| `/mem` | Capture insights about flows |
+| `/flow` | Document flows (you are here) |
+| `/pattern` | Document reusable patterns |

--- a/.claude/commands/pattern.md
+++ b/.claude/commands/pattern.md
@@ -1,0 +1,98 @@
+---
+description: Document reusable design patterns with structure and examples
+---
+
+# Pattern - Design Pattern Library
+
+Document reusable design patterns with structure, examples, and usage guidelines.
+
+## Usage
+
+```
+/pattern [name]
+/pattern retry-with-backoff
+/pattern worker-coordination
+```
+
+**Output:** `$PROJECT_ROOT/docs/patterns/[name].md`
+
+## Instructions
+
+1. **Parse name** → kebab-case filename
+2. **Ask user** about the pattern:
+   - What type? (behavioral/structural/creational)
+   - What problem does it solve?
+   - What language for the example?
+3. **Generate** pattern document
+4. **Save** to `docs/patterns/[name].md`
+
+## Template
+
+```markdown
+# [Pattern Name]
+
+| Field | Value |
+|-------|-------|
+| Type | Behavioral / Structural / Creational |
+| Language | [primary language] |
+| Tags | [tag1, tag2] |
+| Created | YYYY-MM-DD |
+
+## Intent
+
+> One sentence describing what this pattern solves.
+
+## Problem
+
+What situation triggers the need for this pattern?
+
+## Solution
+
+How the pattern addresses the problem.
+
+## Structure
+
+```[language]
+// Key interfaces/types
+```
+
+## Example
+
+```[language]
+// Complete working example
+```
+
+## When to Use
+
+- Situation 1
+- Situation 2
+
+## When NOT to Use
+
+- Anti-situation 1
+- Anti-situation 2
+
+## Trade-offs
+
+| Pro | Con |
+|-----|-----|
+| [benefit] | [cost] |
+
+## Related Patterns
+
+- [Pattern A] - [relationship]
+- [Pattern B] - [relationship]
+
+## References
+
+- [link or source]
+```
+
+## Related Commands
+
+| Command | Purpose |
+|---------|---------|
+| `/distill` | Extract patterns from learnings |
+| `/example` | Save code examples |
+| `/pattern` | Document patterns (you are here) |
+| `/search` | Find existing patterns |

--- a/.claude/commands/search.md
+++ b/.claude/commands/search.md
@@ -1,0 +1,101 @@
+---
+description: Search knowledge base by title, tags, or content
+---
+
+# Search - Knowledge Search
+
+Search across learnings, knowledge base, retrospectives, and examples.
+
+## Usage
+
+```
+/search [query]
+/search --tag [tag-name]
+/search --type [learning|knowledge|retrospective|example]
+/search --reindex
+```
+
+## Instructions
+
+### If `--reindex` flag is present
+
+Rebuild the index:
+
+```bash
+bash scripts/build-index.sh "$PROJECT_ROOT"
+```
+
+### Otherwise: Search
+
+1. **Check if index exists**, rebuild if not:
+
+```bash
+if [[ ! -f .knowledge-index.json ]]; then
+    bash scripts/build-index.sh "$PROJECT_ROOT"
+fi
+```
+
+2. **Search the index** based on query type:
+
+#### By text query (default)
+Search title, summary, and tags for matching terms:
+
+```bash
+jq --arg q "$QUERY" '
+    .entries[] |
+    select(
+        (.title | ascii_downcase | contains($q | ascii_downcase)) or
+        (.summary | ascii_downcase | contains($q | ascii_downcase)) or
+        (.tags[] | ascii_downcase | contains($q | ascii_downcase))
+    )
+' .knowledge-index.json
+```
+
+#### By tag (`--tag`)
+```bash
+jq --arg tag "$TAG" '
+    .entries[] | select(.tags[] == $tag)
+' .knowledge-index.json
+```
+
+#### By type (`--type`)
+```bash
+jq --arg type "$TYPE" '
+    .entries[] | select(.type == $type)
+' .knowledge-index.json
+```
+
+3. **Present results** in a readable format:
+
+```markdown
+## Search Results for "[query]"
+
+Found [N] results:
+
+| # | Title | Type | Tags | Path |
+|---|-------|------|------|------|
+| 1 | [title] | [type] | [tags] | [path] |
+
+### [1] [Title]
+> [summary snippet]
+Path: `[path]`
+Tags: [tag1], [tag2]
+```
+
+4. **If no results**: Suggest related tags or broader search terms.
+
+## Index Stats
+
+Show index statistics:
+```bash
+jq '{total: .total, types: .types, generated: .generated}' .knowledge-index.json
+```
+
+## Related Commands
+
+| Command | Purpose |
+|---------|---------|
+| `/mem` | Capture learnings (indexed) |
+| `/distill` | Create knowledge entries (indexed) |
+| `/example` | Save code examples (indexed) |
+| `/search` | Search all knowledge (you are here) |

--- a/.claude/commands/share.md
+++ b/.claude/commands/share.md
@@ -1,0 +1,56 @@
+---
+description: Share knowledge across projects by copying to shared-knowledge directory
+---
+
+# Share - Cross-Project Knowledge Sync
+
+Copy project-specific knowledge to the shared directory for reuse across projects.
+
+## Usage
+
+```
+/share [knowledge-file-path]
+/share docs/knowledge-base/retry-pattern.md
+```
+
+**Output:** `$PROJECT_ROOT/docs/shared-knowledge/[filename].md`
+
+## Instructions
+
+1. **Validate** the source file exists and is in docs/
+2. **Copy** to `docs/shared-knowledge/`
+3. **Clean** project-specific references (paths, project names)
+4. **Add** cross-project metadata:
+   - Remove project-specific paths
+   - Add `scope: cross-project` to frontmatter
+   - Add source project reference
+5. **Confirm** with user
+
+## Template Additions
+
+Add to the shared file's frontmatter:
+```yaml
+scope: cross-project
+source_project: [current project name]
+shared_date: YYYY-MM-DD
+```
+
+## Sync to Other Projects
+
+To use shared knowledge in another project:
+
+```bash
+# Option 1: Symlink
+ln -s /path/to/shared-knowledge docs/shared-knowledge
+
+# Option 2: Copy specific files
+cp /path/to/shared-knowledge/pattern.md docs/knowledge-base/
+```
+
+## Related Commands
+
+| Command | Purpose |
+|---------|---------|
+| `/distill` | Create knowledge (can then /share) |
+| `/search` | Find knowledge to share |
+| `/share` | Share cross-project (you are here) |

--- a/.claude/commands/summary.md
+++ b/.claude/commands/summary.md
@@ -1,0 +1,175 @@
+---
+description: Generate weekly or monthly session summaries from retrospectives and activity logs
+---
+
+# Summary - Session Summaries
+
+Generate weekly or monthly summaries from retrospectives, learnings, and activity logs.
+
+## Usage
+
+```
+/summary weekly          # Generate current week summary
+/summary monthly         # Generate current month summary
+/summary weekly 2026-01  # Generate for specific week/month
+```
+
+**Output:** `$PROJECT_ROOT/docs/summaries/YYYY-MM-weekN.md` or `YYYY-MM.md`
+
+## Instructions
+
+### 1. Determine Period
+
+Parse arguments:
+- `weekly` → current week (Mon-Sun)
+- `monthly` → current month
+- Optional date parameter for historical summaries
+
+```bash
+export TZ='Asia/Bangkok'
+YEAR=$(date '+%Y')
+MONTH=$(date '+%m')
+WEEK=$(date '+%V')
+```
+
+### 2. Gather Data
+
+```bash
+export TZ='Asia/Bangkok'
+
+# Activity log entries for the period
+grep "^$YEAR-$MONTH" docs/logs/activity.log
+
+# Retrospectives for the period
+find docs/retrospective/$YEAR-$MONTH -name "*.md" -type f | sort
+
+# Learnings for the period
+find docs/learnings/$YEAR-$MONTH -name "*.md" -type f | sort
+
+# Git commits for the period
+git log --oneline --since="[start-date]" --until="[end-date]"
+
+# Knowledge base updates
+git log --oneline --since="[start-date]" --until="[end-date]" -- docs/knowledge-base/
+```
+
+### 3. Analyze and Generate
+
+Read each retrospective/learning file and extract:
+- Task descriptions
+- Types (feature, bugfix, refactor, etc.)
+- Key decisions
+- Open items (unchecked checkboxes)
+
+### 4. Create Summary File
+
+Use the template below.
+
+### 5. Commit
+
+```bash
+git add docs/summaries/
+git commit -m "docs: [weekly|monthly] summary for [period]"
+```
+
+## Weekly Template
+
+```markdown
+# Week [N] Summary ([start-date] - [end-date])
+
+## Overview
+
+| Metric | Value |
+|--------|-------|
+| Sessions | [count] |
+| Issues Closed | [count] |
+| PRs Merged | [count] |
+| Learnings Captured | [count] |
+
+## Sessions
+
+| Date | Task | Type | Status | Issue |
+|------|------|------|--------|-------|
+| MM-DD | [task description] | feat/fix/refactor | completed/pending | #N |
+
+## Key Accomplishments
+
+- [accomplishment 1]
+- [accomplishment 2]
+
+## Learnings Captured
+
+- `docs/learnings/[path]` - [title]
+
+## Knowledge Distilled
+
+- `docs/knowledge-base/[topic].md` - [title]
+
+## Decisions Made
+
+| Decision | Context | Rationale |
+|----------|---------|-----------|
+| [decision] | [context] | [rationale] |
+
+## Open Items
+
+- [ ] [carried over items from retrospectives]
+
+## Next Week Focus
+
+- [suggested focus areas based on open items]
+```
+
+## Monthly Template
+
+```markdown
+# [Month Year] Summary
+
+## Overview
+
+| Metric | Value |
+|--------|-------|
+| Total Sessions | [count] |
+| Issues Closed | [count] |
+| PRs Merged | [count] |
+| Learnings | [count] |
+| Knowledge Base Updates | [count] |
+
+## Weekly Breakdown
+
+| Week | Sessions | Key Focus |
+|------|----------|-----------|
+| W1 | [count] | [focus] |
+| W2 | [count] | [focus] |
+| W3 | [count] | [focus] |
+| W4 | [count] | [focus] |
+
+## Top Accomplishments
+
+1. [accomplishment]
+2. [accomplishment]
+3. [accomplishment]
+
+## Patterns & Trends
+
+- [observed pattern in work]
+- [recurring themes]
+
+## Open Items Carried Over
+
+- [ ] [items still pending]
+
+## Next Month Priorities
+
+- [priority 1]
+- [priority 2]
+```
+
+## Related Commands
+
+| Command | Purpose |
+|---------|---------|
+| `/td` | Create retrospective (data source) |
+| `/mem` | Capture learnings (data source) |
+| `/consolidate` | Consolidate auto-captured files |
+| `/summary` | Generate summaries (you are here) |


### PR DESCRIPTION
## Summary

Fix commands not appearing in Claude Code skill list by copying them to the correct discovery path.

## Problem

6 new commands (`/example`, `/summary`, `/search`, `/share`, `/flow`, `/pattern`) were added to `assets/commands/` but not to `.claude/commands/`. Claude Code discovers slash commands from `.claude/commands/`, not `assets/commands/`.

## Solution

Copy the 6 command files to `.claude/commands/` where Claude Code can discover them:
- `/example` - Save code examples to library
- `/summary` - Generate weekly/monthly session summaries
- `/search` - Search knowledge index
- `/share` - Share knowledge across projects
- `/flow` - Document process flows with Mermaid
- `/pattern` - Document design patterns